### PR TITLE
Remove unnecessarily import

### DIFF
--- a/Chapter01/tuples.rs
+++ b/Chapter01/tuples.rs
@@ -6,13 +6,11 @@
 
 
 fn main() {
-	
-	// Declaring a tuple
-	let _rand_tuple = ("Mozilla Science Lab", 2016);
-	let rand_tuple2 : (&str, i8) = ("Viki",4);
+    // Declaring a tuple
+    let _rand_tuple = ("Mozilla Science Lab", 2016);
+    let rand_tuple2: (&str, i8) = ("Viki", 4);
 
-	// tuple operations
-	println!(" Name : {}", rand_tuple2.0);
-	println!(" Lucky no : {}", rand_tuple2.1);
-
+    // tuple operations
+    println!(" Name : {}", rand_tuple2.0);
+    println!(" Lucky no : {}", rand_tuple2.1);
 }


### PR DESCRIPTION
Using import `use std::{i8};` is unnecessarily 
Mark first variable as unused - add `_`