### PR TITLE
Remove useless code

### DIFF
--- a/Chapter05/sample_move.rs
+++ b/Chapter05/sample_move.rs
@@ -9,10 +9,8 @@ use std::thread;
 
 fn main() {
     let x = 1;
-    
-    let handle = thread::spawn(move || {
-       	(x)
-    });
 
-    println!("{:?}", handle.join().unwrap());
+    let handle = thread::spawn(move || x);
+
+    println!("{}", handle.join().unwrap());
 }


### PR DESCRIPTION
Remove round brackets around `x` and debugging marker in `println` marcos